### PR TITLE
Fix code scanning alert no. 12: Database query built from user-controlled sources

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -35,7 +35,7 @@ const login = async (req, res) => {
   const { email, password } = req.body;
 
   try {
-    const user = await User.findOne({ email });
+    const user = await User.findOne({ email: { $eq: email } });
     if (user) {
       const originalpassword = CryptoJS.AES.decrypt(
         user.password,


### PR DESCRIPTION
Fixes [https://github.com/gurukudte/Realtime-Chat-app/security/code-scanning/12](https://github.com/gurukudte/Realtime-Chat-app/security/code-scanning/12)

To fix the problem, we need to ensure that the user input is interpreted as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. This will ensure that the `email` field is treated as a literal value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
